### PR TITLE
Feature/nano attachment delayed verdict response body

### DIFF
--- a/attachments/kong/plugins/open-appsec-waf-kong-plugin/lua_attachment_wrapper.c
+++ b/attachments/kong/plugins/open-appsec-waf-kong-plugin/lua_attachment_wrapper.c
@@ -12,7 +12,7 @@ static int lua_init_nano_attachment(lua_State *L) {
     int worker_id = luaL_checkinteger(L, 1);
     int num_workers = luaL_checkinteger(L, 2);
 
-    NanoAttachment* attachment = InitNanoAttachment(0, worker_id, num_workers, fileno(stdout));
+    NanoAttachment* attachment = InitNanoAttachment(0, worker_id, num_workers, fileno(stderr));
     if (!attachment) {
         lua_pushnil(L);
         lua_pushstring(L, "Failed to initialize NanoAttachment");


### PR DESCRIPTION
- Implement TRAFFIC_VERDICT_DELAYED handling in SendResponseBody function
- Add delayed verdict thread spawning when response body returns delayed verdict

This change mirrors the existing delayed verdict handling in SendRequestBody to ensure consistent behavior for both request and response body processing.

Furthermore, redirected Kong output using Nano Attachment from stdout to stderr.