### PR TITLE
Add delayed verdict support for request end in nano attachment

### DIFF
--- a/attachments/nano_attachment/nano_attachment_sender.c
+++ b/attachments/nano_attachment/nano_attachment_sender.c
@@ -712,6 +712,31 @@ SendRequestEnd(NanoAttachment *attachment, AttachmentData *data)
         ctx.res
     );
 
+    if (session_data_p->verdict == TRAFFIC_VERDICT_DELAYED) {
+        write_dbg(attachment, session_id, DBG_LEVEL_DEBUG, "spawn SendDelayedVerdictRequestThread");
+        res = NanoRunInThreadTimeout(
+            attachment,
+            data,
+            SendDelayedVerdictRequestThread,
+            (void *)&ctx,
+            attachment->waiting_for_verdict_thread_timeout_msec,
+            "SendDelayedVerdictRequestThread",
+            RESPONSE
+        );
+        if (!res) {
+            updateMetricField(attachment, HOLD_THREAD_TIMEOUT, 1);
+            return SendThreadTimeoutVerdict(attachment, session_id, &ctx);
+        }
+
+        write_dbg(
+            attachment,
+            session_id,
+            DBG_LEVEL_DEBUG,
+            "finished SendDelayedVerdictRequestThread successfully. res=%d",
+            ctx.res
+        );
+    }
+
     if (ctx.res != NANO_HTTP_FORBIDDEN && ctx.res != NANO_OK) {
         return FinalizeFailedResponse(attachment, session_id, &ctx);
     }


### PR DESCRIPTION
- Implement TRAFFIC_VERDICT_DELAYED handling in SendRequestEnd function
- Add delayed verdict thread spawning when response end returns delayed verdict

This change mirrors the existing delayed verdict handling in SendRequestBody and SendResponseBody to ensure consistent behavior for both request and response body processing.