### PR TITLE
Refactor delayed verdict handling and add configurable retries

### DIFF
--- a/attachments/nano_attachment/nano_attachment.c
+++ b/attachments/nano_attachment/nano_attachment.c
@@ -89,6 +89,8 @@ InitNanoAttachment(uint8_t attachment_type, int worker_id, int num_of_workers, i
     attachment->res_header_thread_timeout_msec = 100;
     attachment->res_body_thread_timeout_msec = 150;
     attachment->waiting_for_verdict_thread_timeout_msec = 150;
+    attachment->hold_verdict_retries = 10;
+    attachment->hold_verdict_polling_time = 1;
     attachment->metric_timeout_timeout = 100;
     attachment->inspection_mode = NON_BLOCKING_THREAD;
     attachment->num_of_nano_ipc_elements = 200;

--- a/attachments/nano_attachment/nano_attachment_util/nano_attachment_util.cc
+++ b/attachments/nano_attachment/nano_attachment_util/nano_attachment_util.cc
@@ -155,6 +155,18 @@ getWaitingForVerdictThreadTimeout()
     return conf_data.getNumericalValue("waiting_for_verdict_thread_timeout_msec");
 }
 
+unsigned int
+getHoldVerdictRetries()
+{
+    return conf_data.getNumericalValue("hold_verdict_retries");
+}
+
+unsigned int
+getHoldVerdictPollingTime()
+{
+    return conf_data.getNumericalValue("hold_verdict_polling_time");
+}
+
 int
 isIPAddress(c_str ip_str)
 {

--- a/attachments/nano_attachment/nano_configuration.c
+++ b/attachments/nano_attachment/nano_configuration.c
@@ -72,6 +72,8 @@ init_attachment_config(NanoAttachment *attachment, const char *conf_path)
     attachment->res_header_thread_timeout_msec = getResHeaderThreadTimeout();
     attachment->res_body_thread_timeout_msec = getResBodyThreadTimeout();
     attachment->waiting_for_verdict_thread_timeout_msec = getWaitingForVerdictThreadTimeout();
+    attachment->hold_verdict_retries = getHoldVerdictRetries();
+    attachment->hold_verdict_polling_time = getHoldVerdictPollingTime();
 
     attachment->num_of_nano_ipc_elements = getNumOfNginxIpcElements();
     attachment->keep_alive_interval_msec = getKeepAliveIntervalMsec();
@@ -105,6 +107,8 @@ init_attachment_config(NanoAttachment *attachment, const char *conf_path)
         "res header thread timeout: %u msec, "
         "res body thread timeout: %u msec, "
         "delayed thread timeout: %u msec, "
+        "hold verdict retries: %u, "
+        "hold verdict polling time: %u msec, "
         "static resources path: %s, "
         "num of nginx ipc elements: %u, "
         "keep alive interval msec: %u msec",
@@ -125,6 +129,8 @@ init_attachment_config(NanoAttachment *attachment, const char *conf_path)
         attachment->res_header_thread_timeout_msec,
         attachment->res_body_thread_timeout_msec,
         attachment->waiting_for_verdict_thread_timeout_msec,
+        attachment->hold_verdict_retries,
+        attachment->hold_verdict_polling_time,
         getStaticResourcesPath(),
         attachment->num_of_nano_ipc_elements,
         attachment->keep_alive_interval_msec

--- a/attachments/nano_attachment/nano_initializer.h
+++ b/attachments/nano_attachment/nano_initializer.h
@@ -72,6 +72,8 @@ typedef struct NanoAttachment {
     unsigned int res_header_thread_timeout_msec; ///< Response header processing timeout in milliseconds.
     unsigned int res_body_thread_timeout_msec; ///< Response body processing timeout in milliseconds.
     unsigned int waiting_for_verdict_thread_timeout_msec; ///< Wait thread processing timeout in milliseconds.
+    unsigned int hold_verdict_retries; ///< Number of retries when handling delayed verdict.
+    unsigned int hold_verdict_polling_time; ///< Polling time in milliseconds between retries when handling delayed verdict.
     unsigned int metric_timeout_timeout; ///< Metric timeout in milliseconds.
     NanoHttpInspectionMode inspection_mode; ///< Default inspection mode.
     unsigned int num_of_nano_ipc_elements; ///< Number of NANO IPC elements.

--- a/core/include/attachments/nano_attachment_util.h
+++ b/core/include/attachments/nano_attachment_util.h
@@ -56,6 +56,8 @@ unsigned int getResHeaderThreadTimeout();
 unsigned int getResBodyThreadTimeout();
 
 unsigned int getWaitingForVerdictThreadTimeout();
+unsigned int getHoldVerdictRetries();
+unsigned int getHoldVerdictPollingTime();
 
 int isIPAddress(c_str ip_str);
 int isSkipSource(c_str ip_str);


### PR DESCRIPTION
Refactor delayed verdict handling and add configurable retries
Extract HandleDelayedVerdict() to eliminate duplication and make
retry count and polling time configurable. Add delayed verdict
handling to SendRequestEnd.